### PR TITLE
fix: change values.js in Paradox to match game grade

### DIFF
--- a/counters/paradox by mofuries/scripts/values.js
+++ b/counters/paradox by mofuries/scripts/values.js
@@ -188,8 +188,8 @@ const modsImgs = {
     
 const gradeImgs = {
   '0': './assets/SSH.svg',
-  '1': './assets/SH.svg',
-  '2': './assets/SS.svg',
+  '1': './assets/SS.svg',
+  '2': './assets/SH.svg',
   '3': './assets/S.svg',
   '4': './assets/A.svg',
   '5': './assets/B.svg',
@@ -198,8 +198,8 @@ const gradeImgs = {
   '8': './assets/none.png',
   '9': './assets/none.png',
   'XH': './assets/SSH.svg',
-  'X': './assets/SH.svg',
-  'SH': './assets/SS.svg',
+  'X': './assets/SS.svg',
+  'SH': './assets/SH.svg',
   'S': './assets/S.svg',
   'A': './assets/A.svg',
   'B': './assets/B.svg',

--- a/counters/paradox by mofuries/scripts/values.js
+++ b/counters/paradox by mofuries/scripts/values.js
@@ -1,4 +1,4 @@
-const version = "v1.1.2";
+const version = "v1.1.3";
 const channel = "";
 let isLatest;
 


### PR DESCRIPTION
Before this fix, the SS image was shown where SH should be, and vice versa, causing confusion with in‑game grades.
So I swapped the `SS.svg` and `SH.svg` in `gradeImgs` so that the displayed images now match the actual grade in the game. 