### PR TITLE
Fix (PP by Belikhun): Correct API field for fetching current time

### DIFF
--- a/counters/PP by Belikhun/pp.js
+++ b/counters/PP by Belikhun/pp.js
@@ -184,10 +184,10 @@ const PPPanel = {
 			}
 		}, { duration: 0.2 });
 
-		app.subscribe("currentTime", (value) => {
+		app.subscribe("beatmap.time.live", (value) => {
 			this.currentTime = value;
 			this.requestRender();
-		}, "precise");
+		});
 
 		app.subscribe("beatmap.time.firstObject", (value) => {
 			this.timeFrom = value;


### PR DESCRIPTION
In the latest versions of tosu, the `v2/precise` WebSocket channel no longer returns `currentTime`. Instead, the current time variable should be fetched from `beatmap.time.live` in the v2 API.

Due to the outdated variable name, the real-time PP panel doesn't work correctly. The "PP if FC" and "Max Achievable PP" are not dynamically calculated during gameplay, and the 100, 50, and miss hit indicators stack up at the beginning of the timeline instead of appearing at their correct time ticks.

This PR fixes this bug, ensuring the real-time PP panel works as expected.